### PR TITLE
chore(ci): ARC fallback via vars.CI_RUNNER (Issue #111)

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -44,7 +44,7 @@ jobs:
 
   publish:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     if: startsWith(github.ref, 'refs/tags/vscode-v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true')
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Uses GitHub-hosted ubuntu-latest by default. When org var CI_RUNNER is set to 'arc-runner-set' (billing-block fallback), workflows auto-switch to self-hosted ARC. Zero downtime toggle. Rollback: delete the org var.