### PR TITLE
chore(ci): migrate workflows to ARC via vars.CI_RUNNER (Issue #72)

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ vars.CI_RUNNER }}
     steps:
       - uses: actions/checkout@v4
 
@@ -44,7 +44,7 @@ jobs:
 
   publish:
     needs: build
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ${{ vars.CI_RUNNER }}
     if: startsWith(github.ref, 'refs/tags/vscode-v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true')
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What changed
Migrated every workflow in this repo from hosted `ubuntu-*` runners to the self-hosted ARC scale-set via the `CI_RUNNER` org variable.

Files touched:
- .github/workflows/vscode-extension.yml

## Why
- GitHub Actions hosted-runner billing was blocking org-wide CI/CD.
- ARC scale-set `arc-runner-set` is replicable infra running in-cluster.
- Dev-mirrors-prod (CLAUDE.md §8): same `runs-on` label across all envs.

## Test plan
- Merge; push any commit on `dev` or open a PR.
- Verify the workflow run's runner name starts with `arc-runner-set-`.

## Risk
Low — label-only change, no workflow logic altered. Self-hosted / macos / windows runners (if any) are untouched.

Closes #72
